### PR TITLE
Matches endpoint

### DIFF
--- a/src/main/java/ch/wisv/toornament/ToornamentClient.java
+++ b/src/main/java/ch/wisv/toornament/ToornamentClient.java
@@ -1,7 +1,9 @@
 package ch.wisv.toornament;
 
 import ch.wisv.toornament.concepts.Disciplines;
+import ch.wisv.toornament.concepts.Matches;
 import ch.wisv.toornament.concepts.Tournaments;
+import ch.wisv.toornament.model.TournamentDetails;
 import ch.wisv.toornament.model.request.ApiTokenRequest;
 import ch.wisv.toornament.model.response.ApiTokenResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -48,6 +50,14 @@ public class ToornamentClient {
 
     public Disciplines disciplines() {
         return new Disciplines(this);
+    }
+
+    public Matches matches(TournamentDetails tournament) {
+        return new Matches(this, tournament);
+    }
+
+    public Matches matches(String tournamentId) {
+        return new Matches(this, tournaments().getTournament(tournamentId));
     }
 
     public void authorize() {

--- a/src/main/java/ch/wisv/toornament/concepts/Matches.java
+++ b/src/main/java/ch/wisv/toornament/concepts/Matches.java
@@ -4,6 +4,7 @@ import ch.wisv.toornament.ToornamentClient;
 import ch.wisv.toornament.exception.ToornamentException;
 import ch.wisv.toornament.model.Match;
 import ch.wisv.toornament.model.MatchDetails;
+import ch.wisv.toornament.model.MatchResult;
 import ch.wisv.toornament.model.TournamentDetails;
 import ch.wisv.toornament.model.enums.MatchSort;
 import okhttp3.HttpUrl;
@@ -72,6 +73,22 @@ public class Matches extends Concept {
                 .build();
             String responseBody = client.executeRequest(request).body().string();
             return mapper.readValue(responseBody, MatchDetails.class);
+        } catch (IOException e) {
+            e.printStackTrace();
+            throw new ToornamentException("Got IOException getting match with ID " + matchId);
+        }
+    }
+
+    public MatchResult getResult(String matchId) {
+        try {
+            Request request = client.getAuthenticatedRequestBuilder()
+                .get()
+                .url("https://api.toornament.com/v1/tournaments/" + tournament.getId()
+                    + "/matches/" + matchId
+                    + "/result")
+                .build();
+            String responseBody = client.executeRequest(request).body().string();
+            return mapper.readValue(responseBody, MatchResult.class);
         } catch (IOException e) {
             e.printStackTrace();
             throw new ToornamentException("Got IOException getting match with ID " + matchId);

--- a/src/main/java/ch/wisv/toornament/concepts/Matches.java
+++ b/src/main/java/ch/wisv/toornament/concepts/Matches.java
@@ -6,12 +6,13 @@ import ch.wisv.toornament.model.Match;
 import ch.wisv.toornament.model.MatchDetails;
 import ch.wisv.toornament.model.MatchResult;
 import ch.wisv.toornament.model.TournamentDetails;
-import ch.wisv.toornament.model.enums.MatchSort;
+import ch.wisv.toornament.model.request.MatchQueryBuilder;
 import okhttp3.HttpUrl;
 import okhttp3.Request;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 public class Matches extends Concept {
     private TournamentDetails tournament;
@@ -22,34 +23,23 @@ public class Matches extends Concept {
     }
 
     public List<Match> getMatches() {
-        return getMatches(false, null, null, null, MatchSort.SCHEDULE, null, false);
+        return getMatches(new MatchQueryBuilder());
     }
 
-    public List<Match> getMatches(boolean hasResult, Integer stageNumber, Integer groupNumber, Integer roundNumber,
-                                  MatchSort sort, String participantId, boolean withGames) {
+    public List<Match> getMatches(MatchQueryBuilder builder) {
+        Map<String, String> parameterMap = builder.build();
         try {
             HttpUrl.Builder urlBuilder = new HttpUrl.Builder()
                 .scheme("https")
                 .host("api.toornament.com")
-                .addPathSegment("v1/tournaments")
+                .addPathSegment("v1")
+                .addPathSegment("tournaments")
                 .addPathSegment(tournament.getId())
-                .addPathSegment("matches")
-                .addQueryParameter("has_result", hasResult ? "1" : "0");
+                .addPathSegment("matches");
 
-            if (stageNumber != null) {
-                urlBuilder.addQueryParameter("stage_number", String.valueOf(stageNumber));
+            for (Map.Entry<String, String> parameter : parameterMap.entrySet()) {
+                urlBuilder.addQueryParameter(parameter.getKey(), parameter.getValue());
             }
-            if (groupNumber != null) {
-                urlBuilder.addQueryParameter("group_number", String.valueOf(groupNumber));
-            }
-            if (roundNumber != null) {
-                urlBuilder.addQueryParameter("round_number", String.valueOf(roundNumber));
-            }
-            urlBuilder.addQueryParameter("sort", sort.getName());
-            if (participantId != null) {
-                urlBuilder.addQueryParameter("participant_id", participantId);
-            }
-            urlBuilder.addQueryParameter("with_games", withGames ? "1" : "0");
 
             Request request = client.getAuthenticatedRequestBuilder()
                 .get()

--- a/src/main/java/ch/wisv/toornament/concepts/Matches.java
+++ b/src/main/java/ch/wisv/toornament/concepts/Matches.java
@@ -1,0 +1,80 @@
+package ch.wisv.toornament.concepts;
+
+import ch.wisv.toornament.ToornamentClient;
+import ch.wisv.toornament.exception.ToornamentException;
+import ch.wisv.toornament.model.Match;
+import ch.wisv.toornament.model.MatchDetails;
+import ch.wisv.toornament.model.TournamentDetails;
+import ch.wisv.toornament.model.enums.MatchSort;
+import okhttp3.HttpUrl;
+import okhttp3.Request;
+
+import java.io.IOException;
+import java.util.List;
+
+public class Matches extends Concept {
+    private TournamentDetails tournament;
+
+    public Matches(ToornamentClient client, TournamentDetails tournament) {
+        super(client);
+        this.tournament = tournament;
+    }
+
+    public List<Match> getMatches() {
+        return getMatches(false, null, null, null, MatchSort.SCHEDULE, null, false);
+    }
+
+    public List<Match> getMatches(boolean hasResult, Integer stageNumber, Integer groupNumber, Integer roundNumber,
+                                  MatchSort sort, String participantId, boolean withGames) {
+        try {
+            HttpUrl.Builder urlBuilder = new HttpUrl.Builder()
+                .scheme("https")
+                .host("api.toornament.com")
+                .addPathSegment("v1/tournaments")
+                .addPathSegment(tournament.getId())
+                .addPathSegment("matches")
+                .addQueryParameter("has_result", hasResult ? "1" : "0");
+
+            if (stageNumber != null) {
+                urlBuilder.addQueryParameter("stage_number", String.valueOf(stageNumber));
+            }
+            if (groupNumber != null) {
+                urlBuilder.addQueryParameter("group_number", String.valueOf(groupNumber));
+            }
+            if (roundNumber != null) {
+                urlBuilder.addQueryParameter("round_number", String.valueOf(roundNumber));
+            }
+            urlBuilder.addQueryParameter("sort", sort.getName());
+            if (participantId != null) {
+                urlBuilder.addQueryParameter("participant_id", participantId);
+            }
+            urlBuilder.addQueryParameter("with_games", withGames ? "1" : "0");
+
+            Request request = client.getAuthenticatedRequestBuilder()
+                .get()
+                .url(urlBuilder.toString())
+                .build();
+            String responseBody = client.executeRequest(request).body().string();
+            return mapper.readValue(responseBody, mapper.getTypeFactory().constructCollectionType(List.class, Match.class));
+        } catch (IOException e) {
+            e.printStackTrace();
+            throw new ToornamentException("Got IOExcption getting matches");
+        }
+    }
+
+    public MatchDetails getMatch(String matchId, boolean withGames) {
+        try {
+            Request request = client.getAuthenticatedRequestBuilder()
+                .get()
+                .url("https://api.toornament.com/v1/tournaments/" + tournament.getId()
+                    + "/matches/" + matchId
+                    + "?with_games=" + (withGames ? "1" : "0"))
+                .build();
+            String responseBody = client.executeRequest(request).body().string();
+            return mapper.readValue(responseBody, MatchDetails.class);
+        } catch (IOException e) {
+            e.printStackTrace();
+            throw new ToornamentException("Got IOException getting match with ID " + matchId);
+        }
+    }
+}

--- a/src/main/java/ch/wisv/toornament/concepts/Tournaments.java
+++ b/src/main/java/ch/wisv/toornament/concepts/Tournaments.java
@@ -2,7 +2,7 @@ package ch.wisv.toornament.concepts;
 
 import ch.wisv.toornament.ToornamentClient;
 import ch.wisv.toornament.exception.ToornamentException;
-import ch.wisv.toornament.model.ParticipantType;
+import ch.wisv.toornament.model.enums.ParticipantType;
 import ch.wisv.toornament.model.Tournament;
 import ch.wisv.toornament.model.TournamentDetails;
 import ch.wisv.toornament.model.request.TournamentRequest;
@@ -54,7 +54,7 @@ public class Tournaments extends Concept {
 
 
     }
-    
+
     public List<Tournament> getTournamentByDiscipline(String discipline) {
         Request request = client.getAuthenticatedRequestBuilder()
             .get()

--- a/src/main/java/ch/wisv/toornament/model/Game.java
+++ b/src/main/java/ch/wisv/toornament/model/Game.java
@@ -1,11 +1,55 @@
 package ch.wisv.toornament.model;
 
 import ch.wisv.toornament.model.enums.MatchStatus;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonFormat;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class Game {
     private int number;
     private MatchStatus status;
     private List<Opponent> opponents;
+
+    private Map<String, Object[]> disciplineFields = new HashMap<>();
+
+
+    public int getNumber() {
+        return number;
+    }
+
+    public void setNumber(int number) {
+        this.number = number;
+    }
+
+    public MatchStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(MatchStatus status) {
+        this.status = status;
+    }
+
+    public List<Opponent> getOpponents() {
+        return opponents;
+    }
+
+    public void setOpponents(List<Opponent> opponents) {
+        this.opponents = opponents;
+    }
+
+    // Capture all other fields that Jackson do not match other members
+    @JsonAnyGetter
+    public Map<String, Object[]> otherFields() {
+        return disciplineFields;
+    }
+
+    @JsonAnySetter
+    @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
+    public void setOtherField(String name, Object[] value) {
+        disciplineFields.put(name, value);
+    }
 }

--- a/src/main/java/ch/wisv/toornament/model/Game.java
+++ b/src/main/java/ch/wisv/toornament/model/Game.java
@@ -1,4 +1,11 @@
 package ch.wisv.toornament.model;
 
+import ch.wisv.toornament.model.enums.MatchStatus;
+
+import java.util.List;
+
 public class Game {
+    private int number;
+    private MatchStatus status;
+    private List<Opponent> opponents;
 }

--- a/src/main/java/ch/wisv/toornament/model/Match.java
+++ b/src/main/java/ch/wisv/toornament/model/Match.java
@@ -1,4 +1,144 @@
 package ch.wisv.toornament.model;
 
+import ch.wisv.toornament.model.enums.MatchFormat;
+import ch.wisv.toornament.model.enums.MatchStatus;
+import ch.wisv.toornament.model.enums.MatchType;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Date;
+import java.util.List;
+
 public class Match {
+
+    private String id;
+    private MatchType type;
+    private String discipline;
+    private MatchStatus status;
+    @JsonProperty("tournament_id")
+    private String tournamentId;
+    private int number;
+    @JsonProperty("stage_number")
+    private int stageNumber;
+    @JsonProperty("group_number")
+    private int groupNumber;
+    @JsonProperty("round_number")
+    private int roundNumber;
+    private Date date;
+    private String timezone;
+    @JsonProperty("match_format")
+    private MatchFormat matchFormat;
+    private List<Opponent> opponents;
+    private List<Game> games;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public MatchType getType() {
+        return type;
+    }
+
+    public void setType(MatchType type) {
+        this.type = type;
+    }
+
+    public String getDiscipline() {
+        return discipline;
+    }
+
+    public void setDiscipline(String discipline) {
+        this.discipline = discipline;
+    }
+
+    public MatchStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(MatchStatus status) {
+        this.status = status;
+    }
+
+    public String getTournamentId() {
+        return tournamentId;
+    }
+
+    public void setTournamentId(String tournamentId) {
+        this.tournamentId = tournamentId;
+    }
+
+    public int getNumber() {
+        return number;
+    }
+
+    public void setNumber(int number) {
+        this.number = number;
+    }
+
+    public int getStageNumber() {
+        return stageNumber;
+    }
+
+    public void setStageNumber(int stageNumber) {
+        this.stageNumber = stageNumber;
+    }
+
+    public int getGroupNumber() {
+        return groupNumber;
+    }
+
+    public void setGroupNumber(int groupNumber) {
+        this.groupNumber = groupNumber;
+    }
+
+    public int getRoundNumber() {
+        return roundNumber;
+    }
+
+    public void setRoundNumber(int roundNumber) {
+        this.roundNumber = roundNumber;
+    }
+
+    public Date getDate() {
+        return date;
+    }
+
+    public void setDate(Date date) {
+        this.date = date;
+    }
+
+    public String getTimezone() {
+        return timezone;
+    }
+
+    public void setTimezone(String timezone) {
+        this.timezone = timezone;
+    }
+
+    public MatchFormat getMatchFormat() {
+        return matchFormat;
+    }
+
+    public void setMatchFormat(MatchFormat matchFormat) {
+        this.matchFormat = matchFormat;
+    }
+
+    public List<Opponent> getOpponents() {
+        return opponents;
+    }
+
+    public void setOpponents(List<Opponent> opponents) {
+        this.opponents = opponents;
+    }
+
+    public List<Game> getGames() {
+        return games;
+    }
+
+    public void setGames(List<Game> games) {
+        this.games = games;
+    }
 }

--- a/src/main/java/ch/wisv/toornament/model/MatchDetails.java
+++ b/src/main/java/ch/wisv/toornament/model/MatchDetails.java
@@ -1,0 +1,46 @@
+package ch.wisv.toornament.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public class MatchDetails extends Match {
+
+    private List<Stream> streams;
+    private List<Vod> vods;
+    @JsonProperty("private_note")
+    private String privateNote;
+    private String note;
+
+    public List<Stream> getStreams() {
+        return streams;
+    }
+
+    public void setStreams(List<Stream> streams) {
+        this.streams = streams;
+    }
+
+    public List<Vod> getVods() {
+        return vods;
+    }
+
+    public void setVods(List<Vod> vods) {
+        this.vods = vods;
+    }
+
+    public String getPrivateNote() {
+        return privateNote;
+    }
+
+    public void setPrivateNote(String privateNote) {
+        this.privateNote = privateNote;
+    }
+
+    public String getNote() {
+        return note;
+    }
+
+    public void setNote(String note) {
+        this.note = note;
+    }
+}

--- a/src/main/java/ch/wisv/toornament/model/MatchResult.java
+++ b/src/main/java/ch/wisv/toornament/model/MatchResult.java
@@ -1,0 +1,27 @@
+package ch.wisv.toornament.model;
+
+import ch.wisv.toornament.model.enums.MatchStatus;
+
+import java.util.List;
+
+public class MatchResult {
+
+    private MatchStatus status;
+    private List<Opponent> opponents;
+
+    public MatchStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(MatchStatus status) {
+        this.status = status;
+    }
+
+    public List<Opponent> getOpponents() {
+        return opponents;
+    }
+
+    public void setOpponents(List<Opponent> opponents) {
+        this.opponents = opponents;
+    }
+}

--- a/src/main/java/ch/wisv/toornament/model/Opponent.java
+++ b/src/main/java/ch/wisv/toornament/model/Opponent.java
@@ -1,0 +1,60 @@
+package ch.wisv.toornament.model;
+
+import ch.wisv.toornament.model.enums.Result;
+
+class Opponent {
+    private int number;
+    private Participant participant;
+    private Result result;
+    private Integer rank;
+    private Integer score;
+    private boolean forfeit;
+
+    public int getNumber() {
+        return number;
+    }
+
+    public void setNumber(int number) {
+        this.number = number;
+    }
+
+    public Participant getParticipant() {
+        return participant;
+    }
+
+    public void setParticipant(Participant participant) {
+        this.participant = participant;
+    }
+
+    public Result getResult() {
+        return result;
+    }
+
+    public void setResult(Result result) {
+        this.result = result;
+    }
+
+    public Integer getScore() {
+        return score;
+    }
+
+    public void setScore(Integer score) {
+        this.score = score;
+    }
+
+    public boolean isForfeit() {
+        return forfeit;
+    }
+
+    public void setForfeit(boolean forfeit) {
+        this.forfeit = forfeit;
+    }
+
+    public Integer getRank() {
+        return rank;
+    }
+
+    public void setRank(Integer rank) {
+        this.rank = rank;
+    }
+}

--- a/src/main/java/ch/wisv/toornament/model/Participant.java
+++ b/src/main/java/ch/wisv/toornament/model/Participant.java
@@ -1,4 +1,32 @@
 package ch.wisv.toornament.model;
 
 public class Participant {
+
+    private String id;
+    private String name;
+    private String country;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getCountry() {
+        return country;
+    }
+
+    public void setCountry(String country) {
+        this.country = country;
+    }
 }

--- a/src/main/java/ch/wisv/toornament/model/Stream.java
+++ b/src/main/java/ch/wisv/toornament/model/Stream.java
@@ -1,0 +1,14 @@
+package ch.wisv.toornament.model;
+
+public class Stream extends Video {
+
+    private String id;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+}

--- a/src/main/java/ch/wisv/toornament/model/Tournament.java
+++ b/src/main/java/ch/wisv/toornament/model/Tournament.java
@@ -1,5 +1,6 @@
 package ch.wisv.toornament.model;
 
+import ch.wisv.toornament.model.enums.TournamentStatus;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Date;
@@ -11,7 +12,7 @@ public class Tournament {
     private String name;
     @JsonProperty("full_name")
     private String fullName;
-    private Status status;
+    private TournamentStatus status;
     @JsonProperty("date_start")
     private Date dateStart;
     @JsonProperty("date_end")
@@ -59,12 +60,12 @@ public class Tournament {
         this.fullName = fullName;
     }
 
-    public Status getStatus() {
+    public TournamentStatus getStatus() {
         return this.status;
     }
 
-    public void setStatus(Status status) {
-        this.status = status;
+    public void setStatus(TournamentStatus tournamentStatus) {
+        this.status = tournamentStatus;
     }
 
     public Date getDateStart() {

--- a/src/main/java/ch/wisv/toornament/model/TournamentDetails.java
+++ b/src/main/java/ch/wisv/toornament/model/TournamentDetails.java
@@ -1,5 +1,8 @@
 package ch.wisv.toornament.model;
 
+import ch.wisv.toornament.model.enums.MatchFormat;
+import ch.wisv.toornament.model.enums.MatchType;
+import ch.wisv.toornament.model.enums.ParticipantType;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonFormat;

--- a/src/main/java/ch/wisv/toornament/model/Video.java
+++ b/src/main/java/ch/wisv/toornament/model/Video.java
@@ -1,0 +1,32 @@
+package ch.wisv.toornament.model;
+
+public abstract class Video {
+
+    private String name;
+    private String url;
+    private String language;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public String getLanguage() {
+        return language;
+    }
+
+    public void setLanguage(String language) {
+        this.language = language;
+    }
+}

--- a/src/main/java/ch/wisv/toornament/model/Vod.java
+++ b/src/main/java/ch/wisv/toornament/model/Vod.java
@@ -1,0 +1,16 @@
+package ch.wisv.toornament.model;
+
+import ch.wisv.toornament.model.enums.VodCategory;
+
+public class Vod extends Video {
+
+    private VodCategory category;
+
+    public VodCategory getCategory() {
+        return category;
+    }
+
+    public void setCategory(VodCategory category) {
+        this.category = category;
+    }
+}

--- a/src/main/java/ch/wisv/toornament/model/enums/DateSort.java
+++ b/src/main/java/ch/wisv/toornament/model/enums/DateSort.java
@@ -1,0 +1,5 @@
+package ch.wisv.toornament.model.enums;
+
+public enum DateSort {
+    DATE_ASC, DATE_DESC
+}

--- a/src/main/java/ch/wisv/toornament/model/enums/MatchFormat.java
+++ b/src/main/java/ch/wisv/toornament/model/enums/MatchFormat.java
@@ -1,13 +1,13 @@
-package ch.wisv.toornament.model;
+package ch.wisv.toornament.model.enums;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum ParticipantType {
-    TEAM("team"), SINGLE("single");
+public enum MatchFormat {
+    NONE("none"), ONE("one"), HOME_AWAY("home_away"), BO3("bo3"), BO5("bo5"), BO7("bo7"), BO9("bo9"), BO11("bo11");
 
     private String name;
 
-    ParticipantType(String name) {
+    MatchFormat(String name) {
         this.name = name;
     }
 

--- a/src/main/java/ch/wisv/toornament/model/enums/MatchSort.java
+++ b/src/main/java/ch/wisv/toornament/model/enums/MatchSort.java
@@ -1,0 +1,18 @@
+package ch.wisv.toornament.model.enums;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum MatchSort {
+    STRUCTURE("structure"), SCHEDULE("schedule"), LATEST("latest");
+
+    private String name;
+
+    MatchSort(String name) {
+        this.name = name;
+    }
+
+    @JsonValue
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/ch/wisv/toornament/model/enums/MatchStatus.java
+++ b/src/main/java/ch/wisv/toornament/model/enums/MatchStatus.java
@@ -1,0 +1,12 @@
+package ch.wisv.toornament.model.enums;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum MatchStatus {
+    @JsonProperty("pending")
+    PENDING,
+    @JsonProperty("running")
+    RUNNING,
+    @JsonProperty("completed")
+    COMPLETED
+}

--- a/src/main/java/ch/wisv/toornament/model/enums/MatchType.java
+++ b/src/main/java/ch/wisv/toornament/model/enums/MatchType.java
@@ -1,13 +1,13 @@
-package ch.wisv.toornament.model;
+package ch.wisv.toornament.model.enums;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum MatchFormat {
-    NONE("none"), ONE("one"), HOME_AWAY("home_away"), BO3("bo3"), BO5("bo5"), BO7("bo7"), BO9("bo9"), BO11("bo11");
+public enum MatchType {
+    DUEL("duel"), FFA("ffa");
 
     private String name;
 
-    MatchFormat(String name) {
+    MatchType(String name) {
         this.name = name;
     }
 

--- a/src/main/java/ch/wisv/toornament/model/enums/ParticipantType.java
+++ b/src/main/java/ch/wisv/toornament/model/enums/ParticipantType.java
@@ -1,13 +1,13 @@
-package ch.wisv.toornament.model;
+package ch.wisv.toornament.model.enums;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum MatchType {
-    DUEL("duel"), FFA("ffa");
+public enum ParticipantType {
+    TEAM("team"), SINGLE("single");
 
     private String name;
 
-    MatchType(String name) {
+    ParticipantType(String name) {
         this.name = name;
     }
 

--- a/src/main/java/ch/wisv/toornament/model/enums/Result.java
+++ b/src/main/java/ch/wisv/toornament/model/enums/Result.java
@@ -1,0 +1,12 @@
+package ch.wisv.toornament.model.enums;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum Result {
+    @JsonProperty("1")
+    WIN,
+    @JsonProperty("2")
+    DRAW,
+    @JsonProperty("3")
+    LOSS;
+}

--- a/src/main/java/ch/wisv/toornament/model/enums/Result.java
+++ b/src/main/java/ch/wisv/toornament/model/enums/Result.java
@@ -1,12 +1,15 @@
 package ch.wisv.toornament.model.enums;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum Result {
-    @JsonProperty("1")
+    UNKNOWN,
     WIN,
-    @JsonProperty("2")
     DRAW,
-    @JsonProperty("3")
     LOSS;
+
+    @JsonValue
+    public int toValue() {
+        return ordinal();
+    }
 }

--- a/src/main/java/ch/wisv/toornament/model/enums/Sort.java
+++ b/src/main/java/ch/wisv/toornament/model/enums/Sort.java
@@ -1,4 +1,4 @@
-package ch.wisv.toornament.model;
+package ch.wisv.toornament.model.enums;
 
 public enum Sort {
     DATE_ASC, DATE_DESC

--- a/src/main/java/ch/wisv/toornament/model/enums/TournamentStatus.java
+++ b/src/main/java/ch/wisv/toornament/model/enums/TournamentStatus.java
@@ -1,8 +1,8 @@
-package ch.wisv.toornament.model;
+package ch.wisv.toornament.model.enums;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public enum Status {
+public enum TournamentStatus {
     @JsonProperty("setup")
     SETUP,
     @JsonProperty("running")

--- a/src/main/java/ch/wisv/toornament/model/enums/VodCategory.java
+++ b/src/main/java/ch/wisv/toornament/model/enums/VodCategory.java
@@ -1,0 +1,13 @@
+package ch.wisv.toornament.model.enums;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum VodCategory {
+
+    @JsonProperty("replay")
+    REPLAY,
+    @JsonProperty("highlight")
+    HIGHLIGHT,
+    @JsonProperty("bonus")
+    BONUS;
+}

--- a/src/main/java/ch/wisv/toornament/model/request/MatchQueryBuilder.java
+++ b/src/main/java/ch/wisv/toornament/model/request/MatchQueryBuilder.java
@@ -1,0 +1,75 @@
+package ch.wisv.toornament.model.request;
+
+import ch.wisv.toornament.model.enums.MatchSort;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class MatchQueryBuilder {
+
+    private boolean hasResult = false;
+    private Integer stageNumber;
+    private Integer groupNumber;
+    private Integer roundNumber;
+    private MatchSort sort = MatchSort.STRUCTURE;
+    private String participantId;
+    private boolean withGames = false;
+
+    public MatchQueryBuilder withResult(boolean hasResult) {
+        this.hasResult = hasResult;
+        return this;
+    }
+
+    public MatchQueryBuilder stageNumber(int stageNumber) {
+        this.stageNumber = stageNumber;
+        return this;
+    }
+
+    public MatchQueryBuilder groupNumber(int groupNumber) {
+        this.groupNumber = groupNumber;
+        return this;
+    }
+
+    public MatchQueryBuilder roundNumber(int roundNumber) {
+        this.roundNumber = roundNumber;
+        return this;
+    }
+
+    public MatchQueryBuilder sort(MatchSort sort) {
+        this.sort = sort;
+        return this;
+    }
+
+    public MatchQueryBuilder participant(String participantId) {
+        this.participantId = participantId;
+        return this;
+    }
+
+    public MatchQueryBuilder withGames(boolean withGames) {
+        this.withGames = withGames;
+        return this;
+    }
+
+    public Map<String, String> build() {
+        Map<String, String> params = new HashMap<>();
+
+        params.put("has_result", hasResult ? "1" : "0");
+        params.put("sort", sort.getName());
+        params.put("with_games", withGames ? "1" : "0");
+
+        if (stageNumber != null) {
+            params.put("stage_number", String.valueOf(stageNumber));
+        }
+        if (groupNumber != null) {
+            params.put("group_number", String.valueOf(groupNumber));
+        }
+        if (roundNumber != null) {
+            params.put("round_number", String.valueOf(roundNumber));
+        }
+        if (participantId != null) {
+            params.put("participant_id", participantId);
+        }
+
+        return params;
+    }
+}

--- a/src/main/java/ch/wisv/toornament/model/request/TournamentQuery.java
+++ b/src/main/java/ch/wisv/toornament/model/request/TournamentQuery.java
@@ -1,13 +1,13 @@
 package ch.wisv.toornament.model.request;
 
-import java.util.Date;
+import ch.wisv.toornament.model.enums.DateSort;
+import ch.wisv.toornament.model.enums.TournamentStatus;
 
-import ch.wisv.toornament.model.Sort;
-import ch.wisv.toornament.model.Status;
+import java.util.Date;
 
 public class TournamentQuery {
     String discipline;
-    Status status;
+    TournamentStatus status;
     Boolean featured;
     Boolean online;
     String country;
@@ -15,6 +15,6 @@ public class TournamentQuery {
     Date beforeStart;
     Date afterEnd;
     Date beforeEnd;
-    Sort sort = Sort.DATE_DESC;
+    DateSort dateSort = DateSort.DATE_DESC;
     String name;
 }

--- a/src/main/java/ch/wisv/toornament/model/request/TournamentRequest.java
+++ b/src/main/java/ch/wisv/toornament/model/request/TournamentRequest.java
@@ -1,7 +1,7 @@
 package ch.wisv.toornament.model.request;
 
-import ch.wisv.toornament.model.MatchFormat;
-import ch.wisv.toornament.model.ParticipantType;
+import ch.wisv.toornament.model.enums.MatchFormat;
+import ch.wisv.toornament.model.enums.ParticipantType;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Date;


### PR DESCRIPTION
This PR introduces most functionality from the `/matches` endpoint. It uses a Querybuilder for the `getMatches()` method, which can also be used for the equivalent Tournament method. 